### PR TITLE
chore(deploy): include node types in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./hardhat.config.ts", "./rocketh.ts", "./scripts", "./deploy", "./utils"],
   "compilerOptions": {
     "lib": ["es2023"],
+    "types": ["node"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "target": "es2022",


### PR DESCRIPTION
Follow-up to #14 (merged before this one-line fix landed).

Explicitly add `"types": ["node"]` so editors/TS language servers resolve Node globals (`console`, `process`) in the deploy scripts. `tsc` already resolved them via auto-included `@types/node`, but some TS language servers (the IDE) did not, surfacing a false "Cannot find name 'console'" in the deploy scripts.

No behavior change; `tsc --noEmit` stays clean.